### PR TITLE
docs(codex): align Codex caveats with v1.87.0 auto-discovery behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,9 +148,12 @@ Evolver integrates with major agent runtimes through `setup-hooks`. Run it once 
 #### Codex caveats
 
 The Codex CLI exposes `SessionStart` / `Stop` / `PostToolUse` hooks (which is
-how `setup-hooks --platform=codex` wires Evolver in), but it does **not**
-emit a session transcript file the way Cursor / Claude Code / opencode do.
-That means `evolver --review` cannot read raw session logs on Codex.
+how `setup-hooks --platform=codex` wires Evolver in). Codex writes session
+transcripts to `~/.codex/sessions/*.jsonl`, but the Stop hook payload does
+not include a `transcript_path` field. Since v1.87.0, Evolver auto-discovers
+transcripts under `~/.codex/sessions/` (and `~/.claude/projects/` for Claude
+Code) without requiring manual `EVOLVER_CURSOR_TRANSCRIPTS_DIR` export, so
+`evolver --review` can read raw session logs on Codex.
 
 `setup-hooks --platform=codex` is lifecycle integration only; it does not route
 Codex model requests through Evolver Proxy. To route Codex model traffic, run
@@ -160,7 +163,7 @@ command-backed auth runs `evolver proxy-token` or the absolute `node index.js
 proxy-token --settings ...` helper emitted by `scripts/internal-proxy-env.sh
 --codex-config` from a source checkout.
 
-Evolver compensates by reading, in order:
+For additional context, Evolver reads, in order:
 
 1. `MEMORY.md` / `USER.md` in the workspace root (if you maintain them);
 2. the `<!-- evolver-evolution-memory -->` section that

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -99,6 +99,28 @@ evolver setup-hooks --platform=claude-code
 
 通过 `~/.claude/` 向 Claude Code 的 hook 系统注册 Evolver。安装完成后重启 Claude Code CLI。
 
+#### Codex
+
+```bash
+evolver setup-hooks --platform=codex
+```
+
+写入 `~/.codex/hooks.json`，将 hook 脚本安装到 `~/.codex/hooks/`，并在 `config.toml` 中启用 `codex_hooks` 特性。重启 Codex CLI 后生效。
+
+##### Codex 注意事项
+
+Codex CLI 暴露 `SessionStart` / `Stop` / `PostToolUse` 钩子（`setup-hooks --platform=codex` 通过它们接入 Evolver）。Codex 会将会话转写写入 `~/.codex/sessions/*.jsonl`，但 Stop 钩子的 payload 不包含 `transcript_path` 字段。自 v1.87.0 起，Evolver 会自动发现 `~/.codex/sessions/`（以及 Claude Code 的 `~/.claude/projects/`）下的转写文件，无需手动 export `EVOLVER_CURSOR_TRANSCRIPTS_DIR`，因此 `evolver --review` 可以在 Codex 上读取原始会话日志。
+
+`setup-hooks --platform=codex` 仅做生命周期集成，不会将 Codex 的模型请求路由到 Evolver Proxy。如需路由 Codex 的模型流量，请运行 Evolver Proxy，并为 Codex 配置一个用户级 OpenAI Responses 兼容的自定义 provider，其 `base_url` 指向 proxy 的 `/v1` 端点，鉴权命令运行 `evolver proxy-token` 或源码检出中 `scripts/internal-proxy-env.sh --codex-config` 输出的绝对路径 `node index.js proxy-token --settings ...` 辅助脚本。
+
+除会话转写外，Evolver 还按以下顺序读取：
+
+1. 工作区根目录的 `MEMORY.md` / `USER.md`（需自行维护）；
+2. `setup-hooks --platform=codex` 注入到项目 `AGENTS.md` 的 `<!-- evolver-evolution-memory -->` 段落；
+3. 本地 `memory_graph.jsonl` 的尾部（Evolver 自行写入的每轮结果日志）。
+
+如果以上来源在前几轮都还没有内容，你会看到 `memory_missing` / `user_missing` / `session_logs_missing` 作为 advisory 信号出现。随着 `memory_graph.jsonl` 积累结果，这些信号会自行消失——无需手动配置。
+
 #### OpenClaw
 
 OpenClaw 会识别 Evolver 向 stdout 输出的 `sessions_spawn(...)` 协议，**无需安装 hooks**。将 Evolver 克隆到 OpenClaw workspace 中，在会话内运行即可：


### PR DESCRIPTION
## Motivation

The `Codex caveats` section in `README.md` still claims:

> The Codex CLI ... does **not** emit a session transcript file the way Cursor / Claude Code / opencode do. That means `evolver --review` cannot read raw session logs on Codex.

This is factually incorrect and was already addressed in **v1.87.0** (2026-05-26). The issue was raised in #540 and closed by the maintainer (@autogame-17), but the README was never updated to reflect the fix. The maintainer themselves acknowledged in the issue thread that the previous README description over-promised (承诺面比实际宽).

What actually happened (per #540 closing comment):
- `readCursorTranscripts()` was enhanced to auto-discover transcripts under `~/.codex/sessions/` and `~/.claude/projects/` without requiring manual `EVOLVER_CURSOR_TRANSCRIPTS_DIR` export.
- `readMemoryGraphAnyTail()` was added as a tier-2 fallback for `memory_graph.jsonl`.

## Changes

### README.md (Codex caveats section)

- **Fixed factual error**: Replaced "does not emit a session transcript file" with the accurate statement that Codex writes transcripts to `~/.codex/sessions/*.jsonl`, but the Stop hook payload does not include `transcript_path`.
- **Documented v1.87.0 auto-discovery**: Added that Evolver auto-discovers transcripts under `~/.codex/sessions/` (and `~/.claude/projects/` for Claude Code) without manual `EVOLVER_CURSOR_TRANSCRIPTS_DIR` export.
- **Adjusted wording**: Changed "Evolver compensates by reading" to "For additional context, Evolver reads" (transcript discovery is no longer a gap to compensate for, but a working source of session logs).
- **Preserved**: lifecycle integration note, 3-layer memory fallback, advisory signals description.

### README.zh-CN.md (platform integration section)

- **Added missing Codex platform section**: The zh-CN README previously listed only Cursor / Claude Code / OpenClaw — Codex was entirely missing. Added the `setup-hooks --platform=codex` command, description, and a translated `Codex 注意事项` subsection with the same content as the English caveats.

## Verification

- `git diff` reviewed: 2 files changed, 29 insertions(+), 4 deletions(-)
- No code changes (docs-only PR); `node index.js` self-check skipped (no `node_modules` in fresh clone)

## References

- Refs: #540
- v1.87.0 release: https://github.com/EvoMap/evolver/releases/tag/v1.87.0
- Maintainer closing comment in #540: https://github.com/EvoMap/evolver/issues/540#issuecomment-4540567552

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or configuration behavior modified.
> 
> **Overview**
> **English README:** The **Codex caveats** section no longer claims Codex lacks session transcripts or that `evolver --review` cannot read Codex logs. It now states that transcripts live under `~/.codex/sessions/*.jsonl`, that the Stop hook omits `transcript_path`, and that **since v1.87.0** Evolver auto-discovers those paths (and `~/.claude/projects/` for Claude Code) without `EVOLVER_CURSOR_TRANSCRIPTS_DIR`. The memory fallback list is reframed from “compensates” to **“For additional context, Evolver reads”**; proxy/lifecycle notes are unchanged.
> 
> **Chinese README:** Adds a full **Codex** platform block (setup command, proxy note, caveats, memory fallback, advisory signals) that was missing from `README.zh-CN.md`, aligned with the updated English text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1d104401a89d8538c5889d9c01ff4000e6af48c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->