### PR TITLE
test: isolate user state during test runs

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "a2a:export": "node scripts/a2a_export.js",
     "a2a:ingest": "node scripts/a2a_ingest.js",
     "a2a:promote": "node scripts/a2a_promote.js",
-    "test": "node -e \"const fs=require('fs'),cp=require('child_process');const skip=new Set(['solidifyIntegration.test.js','proxyTracePlatformInstall.test.js','spawnReplacementProcess.test.js']);const all=fs.readdirSync('test').filter(f=>f.endsWith('.test.js')&&!skip.has(f));const iso=new Set(['solidifyIntegration.test.js']);const others=all.filter(f=>!iso.has(f)).map(f=>'test/'+f);const isoFiles=all.filter(f=>iso.has(f)).map(f=>'test/'+f);if(others.length)cp.execSync('node --test '+others.join(' '),{stdio:'inherit'});if(isoFiles.length)cp.execSync('node --test '+isoFiles.join(' '),{stdio:'inherit'})\""
+    "test": "node scripts/run-tests.js"
   },
   "engines": {
     "node": ">=22.12"

--- a/scripts/run-tests.js
+++ b/scripts/run-tests.js
@@ -1,0 +1,38 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const repoRoot = path.resolve(__dirname, '..');
+const testDir = path.join(repoRoot, 'test');
+const setupFile = path.join(testDir, 'setup.js');
+const skipped = new Set([
+  'solidifyIntegration.test.js',
+  'proxyTracePlatformInstall.test.js',
+  'spawnReplacementProcess.test.js',
+]);
+
+const testFiles = fs.readdirSync(testDir)
+  .filter((file) => file.endsWith('.test.js') && !skipped.has(file))
+  .sort()
+  .map((file) => path.join('test', file));
+
+const result = spawnSync(process.execPath, [
+  '--require',
+  setupFile,
+  '--test',
+  ...testFiles,
+], {
+  cwd: repoRoot,
+  env: { ...process.env, NODE_ENV: 'test' },
+  stdio: 'inherit',
+});
+
+if (result.error) throw result.error;
+if (result.signal) {
+  console.error(`Test process terminated by ${result.signal}`);
+  process.exitCode = 1;
+} else {
+  process.exitCode = result.status === null ? 1 : result.status;
+}

--- a/test/atpProxyRouting.test.js
+++ b/test/atpProxyRouting.test.js
@@ -56,6 +56,7 @@ describe('ATP hubClient proxy routing (regression #460 Bug 2)', () => {
   const ENV_KEYS = [
     'EVOMAP_PROXY', 'A2A_TRANSPORT', 'A2A_HUB_URL', 'A2A_NODE_ID',
     'A2A_NODE_SECRET', 'EVOMAP_PROXY_PORT', 'EVOMAP_HUB_ALLOW_INSECURE',
+    'EVOLVER_SETTINGS_DIR',
   ];
 
   before(async () => {
@@ -93,6 +94,7 @@ describe('ATP hubClient proxy routing (regression #460 Bug 2)', () => {
     tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'evomap-atp-route-'));
     process.env.HOME = tmpHome;
     process.env.USERPROFILE = tmpHome;
+    process.env.EVOLVER_SETTINGS_DIR = path.join(tmpHome, '.evolver');
 
     // Seed A2A env so hubClient can call getNodeId / buildHubHeaders without
     // touching the filesystem persist path. We mint a fresh 64-hex secret
@@ -129,9 +131,7 @@ describe('ATP hubClient proxy routing (regression #460 Bug 2)', () => {
   });
 
   function writeProxySettings(url) {
-    // settings.js uses os.homedir()/.evolver/settings.json. os.homedir()
-    // on linux reads $HOME which we've swapped to tmpHome above.
-    const settingsDir = path.join(tmpHome, '.evolver');
+    const settingsDir = process.env.EVOLVER_SETTINGS_DIR;
     fs.mkdirSync(settingsDir, { recursive: true });
     fs.writeFileSync(path.join(settingsDir, 'settings.json'), JSON.stringify({
       proxy: { url, pid: process.pid, started_at: new Date().toISOString() },

--- a/test/fixtures/homeIsolationProbe.test.js
+++ b/test/fixtures/homeIsolationProbe.test.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+const test = require('node:test');
+
+test('runs with isolated user state', () => {
+  const parentHome = process.env.EVOLVER_TEST_PARENT_HOME;
+  assert.ok(parentHome);
+  assert.notEqual(process.env.HOME, parentHome);
+  assert.notEqual(process.env.USERPROFILE, parentHome);
+  assert.notEqual(process.env.EVOLVER_HOME, path.join(parentHome, '.evomap'));
+  assert.notEqual(process.env.EVOLVER_SETTINGS_DIR, path.join(parentHome, '.evolver'));
+
+  fs.mkdirSync(process.env.EVOLVER_HOME, { recursive: true });
+  fs.writeFileSync(path.join(process.env.EVOLVER_HOME, 'node_secret'), 'test-only');
+});

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+if (process.env.NODE_TEST_CONTEXT) {
+  const testHome = fs.mkdtempSync(path.join(os.tmpdir(), 'evolver-test-home-'));
+
+  process.env.HOME = testHome;
+  process.env.USERPROFILE = testHome;
+  process.env.EVOLVER_HOME = path.join(testHome, '.evomap');
+  process.env.EVOLVER_SETTINGS_DIR = path.join(testHome, '.evolver');
+
+  process.on('exit', () => {
+    try { fs.rmSync(testHome, { recursive: true, force: true }); } catch {}
+  });
+}

--- a/test/setup.js
+++ b/test/setup.js
@@ -4,15 +4,13 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 
-if (process.env.NODE_TEST_CONTEXT) {
-  const testHome = fs.mkdtempSync(path.join(os.tmpdir(), 'evolver-test-home-'));
+const testHome = fs.mkdtempSync(path.join(os.tmpdir(), 'evolver-test-home-'));
 
-  process.env.HOME = testHome;
-  process.env.USERPROFILE = testHome;
-  process.env.EVOLVER_HOME = path.join(testHome, '.evomap');
-  process.env.EVOLVER_SETTINGS_DIR = path.join(testHome, '.evolver');
+process.env.HOME = testHome;
+process.env.USERPROFILE = testHome;
+process.env.EVOLVER_HOME = path.join(testHome, '.evomap');
+process.env.EVOLVER_SETTINGS_DIR = path.join(testHome, '.evolver');
 
-  process.on('exit', () => {
-    try { fs.rmSync(testHome, { recursive: true, force: true }); } catch {}
-  });
-}
+process.on('exit', () => {
+  try { fs.rmSync(testHome, { recursive: true, force: true }); } catch {}
+});

--- a/test/testHomeIsolation.test.js
+++ b/test/testHomeIsolation.test.js
@@ -17,11 +17,55 @@ test('npm test preloads the isolation setup through the suite runner', () => {
   assert.match(runner, /'--require',\s*setupFile,\s*'--test'/);
 });
 
+test('preload isolates state before a Node test context exists', () => {
+  const parentHome = fs.mkdtempSync(path.join(os.tmpdir(), 'evolver-parent-home-'));
+  const repoRoot = path.resolve(__dirname, '..');
+  const childEnv = {
+    ...process.env,
+    HOME: parentHome,
+    USERPROFILE: parentHome,
+    EVOLVER_HOME: path.join(parentHome, '.evomap'),
+    EVOLVER_SETTINGS_DIR: path.join(parentHome, '.evolver'),
+  };
+  delete childEnv.NODE_TEST_CONTEXT;
+
+  try {
+    const result = spawnSync(process.execPath, [
+      '--require',
+      path.join(repoRoot, 'test', 'setup.js'),
+      '--print',
+      'JSON.stringify([process.env.HOME, process.env.EVOLVER_HOME, process.env.EVOLVER_SETTINGS_DIR])',
+    ], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+      env: childEnv,
+    });
+
+    assert.equal(result.status, 0, result.stdout + result.stderr);
+    const [home, evolverHome, settingsDir] = JSON.parse(result.stdout);
+    assert.notEqual(home, parentHome);
+    assert.notEqual(evolverHome, path.join(parentHome, '.evomap'));
+    assert.notEqual(settingsDir, path.join(parentHome, '.evolver'));
+  } finally {
+    fs.rmSync(parentHome, { recursive: true, force: true });
+  }
+});
+
 test('test setup keeps identity files out of the parent home', () => {
   const parentHome = fs.mkdtempSync(path.join(os.tmpdir(), 'evolver-parent-home-'));
   const repoRoot = path.resolve(__dirname, '..');
 
   try {
+    const childEnv = {
+      ...process.env,
+      HOME: parentHome,
+      USERPROFILE: parentHome,
+      EVOLVER_HOME: path.join(parentHome, '.evomap'),
+      EVOLVER_SETTINGS_DIR: path.join(parentHome, '.evolver'),
+      EVOLVER_TEST_PARENT_HOME: parentHome,
+    };
+    delete childEnv.NODE_TEST_CONTEXT;
+
     const result = spawnSync(process.execPath, [
       '--require',
       path.join(repoRoot, 'test', 'setup.js'),
@@ -30,14 +74,7 @@ test('test setup keeps identity files out of the parent home', () => {
     ], {
       cwd: repoRoot,
       encoding: 'utf8',
-      env: {
-        ...process.env,
-        HOME: parentHome,
-        USERPROFILE: parentHome,
-        EVOLVER_HOME: path.join(parentHome, '.evomap'),
-        EVOLVER_SETTINGS_DIR: path.join(parentHome, '.evolver'),
-        EVOLVER_TEST_PARENT_HOME: parentHome,
-      },
+      env: childEnv,
     });
 
     assert.equal(result.status, 0, result.stdout + result.stderr);

--- a/test/testHomeIsolation.test.js
+++ b/test/testHomeIsolation.test.js
@@ -1,0 +1,49 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawnSync } = require('child_process');
+const test = require('node:test');
+
+test('npm test preloads the isolation setup through the suite runner', () => {
+  const repoRoot = path.resolve(__dirname, '..');
+  const packageJson = JSON.parse(fs.readFileSync(path.join(repoRoot, 'package.json'), 'utf8'));
+  const runner = fs.readFileSync(path.join(repoRoot, 'scripts', 'run-tests.js'), 'utf8');
+
+  assert.equal(packageJson.scripts.test, 'node scripts/run-tests.js');
+  assert.match(runner, /spawnSync\(process\.execPath/);
+  assert.match(runner, /'--require',\s*setupFile,\s*'--test'/);
+});
+
+test('test setup keeps identity files out of the parent home', () => {
+  const parentHome = fs.mkdtempSync(path.join(os.tmpdir(), 'evolver-parent-home-'));
+  const repoRoot = path.resolve(__dirname, '..');
+
+  try {
+    const result = spawnSync(process.execPath, [
+      '--require',
+      path.join(repoRoot, 'test', 'setup.js'),
+      '--test',
+      path.join(repoRoot, 'test', 'fixtures', 'homeIsolationProbe.test.js'),
+    ], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        HOME: parentHome,
+        USERPROFILE: parentHome,
+        EVOLVER_HOME: path.join(parentHome, '.evomap'),
+        EVOLVER_SETTINGS_DIR: path.join(parentHome, '.evolver'),
+        EVOLVER_TEST_PARENT_HOME: parentHome,
+      },
+    });
+
+    assert.equal(result.status, 0, result.stdout + result.stderr);
+    assert.equal(fs.existsSync(path.join(parentHome, '.evomap')), false);
+    assert.equal(fs.existsSync(path.join(parentHome, '.evolver')), false);
+  } finally {
+    fs.rmSync(parentHome, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

Isolate every Node test worker from the developer's real home directory so the suite cannot read or overwrite persistent EvoMap identities, credentials, mailbox state, or proxy settings. Replace the shell-interpolated npm test command with a cross-platform argv-based runner that always preloads the isolation setup.

## What changed

- Added a test-suite runner that starts Node with an explicit argv array and preloads the isolation setup.
- Assigned each test worker a unique temporary HOME, USERPROFILE, EVOLVER_HOME, and EVOLVER_SETTINGS_DIR.
- Removed each temporary test home when its worker exits.
- Added an end-to-end regression test proving identity and settings files stay out of the parent home.
- Updated the ATP proxy routing fixture to honor the isolated settings directory.
- Added no runtime dependencies and changed no production behavior.

## How to test

1. Run `npm test`.
2. Expect 3290 tests to pass with 0 failures.
3. Run `node --test test/testHomeIsolation.test.js`.
4. Expect both isolation regression tests to pass.

## Risk

Low -- this changes only the test entry point and test environment. Revert the commit to restore the previous runner.

## Harness/evaluator governance

Upstream governance surface: N/A
Downstream EvoX impact: N/A
Rollout-local scope: N/A
Promotion boundary: N/A
Evaluator mismatch sets: N/A
Non-regression evidence: N/A
Fix-severity review: N/A
Owner approval: N/A
Security boundary: N/A
Rollback: N/A
Live promotion: no
Autonomous evaluator self-editing: no

## Self-check

- [ ] If this PR adds a new source file under `src/`, it is registered in
      `public.manifest.json` consistently with its sibling files (e.g. listed
      in `obfuscate` when the rest of the directory is). Build verification
      passed: `node scripts/build_public.js` succeeded and the new file shows
      up in `dist-public/` in the expected (obfuscated or plain) form.
- [ ] If this PR adds or modifies a schema factory under `src/gep/schemas/`,
      the corresponding `validate*` function is invoked at every write and
      every publish call site (not just defined).
- [ ] If this PR uses `Object.assign({}, DEFAULTS, partial)` to build an
      object, every reference-typed field (arrays, sub-objects) on the result
      is sliced or cloned -- not held by reference to either source.
- [ ] If this PR introduces a new module-level constant initialized from
      `process.env.X`, the owning module is loaded after the entry point's
      dotenv configuration step (or the constant is migrated to the lazy
      env helpers in `src/config.js`).
- [x] No new runtime dependencies added without a clear justification in the
      "What changed" section above.
- [x] Tests added or updated to cover the new behavior; full suite passes
      locally (`npm test`).

## Related

N/A
