### PR TITLE
docs(readme): fix broken star history chart

### DIFF
--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -497,7 +497,7 @@ MAJOR.MINOR.PATCH
 
 ## Star 履歴
 
-[![Star History Chart](https://api.star-history.com/svg?repos=EvoMap/evolver&type=Date)](https://star-history.com/#EvoMap/evolver&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=EvoMap/evolver&type=Date)](https://star-history.dera.page/#EvoMap/evolver&Date)
 
 ## 謝辞
 

--- a/README.ko-KR.md
+++ b/README.ko-KR.md
@@ -496,7 +496,7 @@ MAJOR.MINOR.PATCH
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=EvoMap/evolver&type=Date)](https://star-history.com/#EvoMap/evolver&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=EvoMap/evolver&type=Date)](https://star-history.dera.page/#EvoMap/evolver&Date)
 
 ## 감사의 말
 

--- a/README.md
+++ b/README.md
@@ -552,7 +552,7 @@ Directional, not commitments — the live backlog lives in [GitHub Issues](https
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=EvoMap/evolver&type=Date)](https://star-history.com/#EvoMap/evolver&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=EvoMap/evolver&type=Date)](https://star-history.dera.page/#EvoMap/evolver&Date)
 
 ## Acknowledgments
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -509,7 +509,7 @@ MAJOR.MINOR.PATCH
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=EvoMap/evolver&type=Date)](https://star-history.com/#EvoMap/evolver&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=EvoMap/evolver&type=Date)](https://star-history.dera.page/#EvoMap/evolver&Date)
 
 ## 鸣谢
 


### PR DESCRIPTION
The star history chart in the README is currently broken and does not render. This change updates the chart and its link to a working mirror so visitors can see the project growth again. The fix is applied to the English README and all localized versions.